### PR TITLE
리듀서 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,7 +71,8 @@ const style = (showDetail: boolean)=>(css`
     .content-box {
       width: 100%;
       display: flex;
-      justify-content: center;
+      padding: 50px 100px;
+      // justify-content: center;
     }
   }
 

--- a/src/components/GatheringDetail.tsx
+++ b/src/components/GatheringDetail.tsx
@@ -406,7 +406,7 @@ const style = css`
             position: relative;
             .floating-box {
                 position: fixed;
-                top: 80px;
+                top: 150px;
                 margin-left: 24px;
                 .title {
                     font-weight: bold;

--- a/src/redux-modules/index.ts
+++ b/src/redux-modules/index.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from "redux";
 import app from './app';
 import gathering from "./gathering";
+import makeTeam from "./makeTeam";
 
 const rootReducer = combineReducers({
     app,
     gathering,
+    makeTeam,
 });
 
 export default rootReducer;

--- a/src/redux-modules/makeTeam.ts
+++ b/src/redux-modules/makeTeam.ts
@@ -1,0 +1,34 @@
+import {TeamInfo} from '../util/interfaces';
+
+const SET_TEAM_INFO = 'makeTeam/SET_TEAM_INFO' as const;
+
+export const setTeamInfo = (arg: TeamInfo | null)=> ({ 
+    type : SET_TEAM_INFO,
+    payload : arg
+});
+
+type actionType = 
+    | ReturnType<typeof setTeamInfo>
+
+type stateType = {
+    teamInfo: TeamInfo | null
+}
+
+const initState: stateType = {
+    teamInfo: null
+};
+
+function makeTeam(state: stateType = initState, action: actionType) {
+    switch (action.type) {
+        case SET_TEAM_INFO:
+            return action.payload ? {
+                teamInfo: {
+                    ...action.payload
+                }
+            } : null;
+        default:
+            return state;
+  }
+}
+
+export default makeTeam;

--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -1,7 +1,3 @@
-export interface test {
-
-}
-
 export interface GatheringInfo {
     id: string;
     filter: string[]
@@ -35,4 +31,8 @@ export interface GatheringInfo {
     purpose: string
     subImgUrls: string[]
     detailDescription: string
+}
+
+export interface TeamInfo {
+    
 }


### PR DESCRIPTION
혜정님, 
팀만들기 / 활동만들기 화면에서 사용할 상태를 관리할 리듀서를 따로 만들어 관리하는게 좋을거 같아서
makeTeam.ts 파일이랑 TeamInfo 인터페이스 추가했습니다.

